### PR TITLE
Add a size parameter for the avatar url

### DIFF
--- a/github/changelogtribe.sh
+++ b/github/changelogtribe.sh
@@ -134,7 +134,7 @@ getUserFullNameFromMetadata() {
 
 getUserAvatarURLFromMetadata() {
   local _id="$1"
-  echo $(echo "$1" | jq .avatar_url | xargs -r echo)
+  echo $(echo "$1" | jq .avatar_url | xargs -r echo)'&s=30'
 }
 
 getTribeAuthorFromGithb() {


### PR DESCRIPTION
Before this fix, avatar is download in full size (460x460). As we display it in 30x30, we can get it in smaller size. This fix add the parameter s, which request for a size on the avatar