### PR TITLE
fix: carry-forward gitOrganization in seed file parsers

### DIFF
--- a/github/rebase-fb.sh
+++ b/github/rebase-fb.sh
@@ -111,11 +111,19 @@ repo_width=45  # Width for the combined org/item column
 branch_width=30
 status_width=12
 ahead_behind_width=20
+last_org=""
 # Iterate over each module and check rebase status
 while IFS=']' read -r line; do
     counter=$((counter+1))  
     item=$(echo $line | awk -F'project:' '{print $2}' | cut -d "," -f 1 | tr -d "'"| xargs)
     org=$(echo $line | awk -F'gitOrganization:' '{print $2}' | cut -d "," -f 1 | tr -d "'" | tr -d "]"| xargs)
+    
+    # Carry-forward gitOrganization from previous entry
+    if [ -z "${org}" ] && [ -n "${last_org}" ]; then
+        org="${last_org}"
+    elif [ -n "${org}" ]; then
+        last_org="${org}"
+    fi
     
     # Skip empty values
     [ -z "${item}" ] && continue

--- a/github/revrebase.sh
+++ b/github/revrebase.sh
@@ -26,9 +26,11 @@ modules_length=$(echo $moduleslist | grep -o 'project:' | wc -w)
 counter=0
 echo "Done. Performing action..."
 ret=0
+last_org=""
 while IFS=']' read -r line; do
     item=$(echo $line | awk -F'project:' '{print $2}' | cut -d "," -f 1 | tr -d "'"| xargs)
     org=$(echo $line | awk -F'gitOrganization:' '{print $2}' | cut -d "," -f 1 | tr -d "'" | tr -d "]"| xargs)
+    if [ -z "${org}" ] && [ -n "${last_org}" ]; then org="${last_org}"; elif [ -n "${org}" ]; then last_org="${org}"; fi
     [ -z "${item}" ] && continue
     [ -z "${org}" ] && continue
     counter=$((counter+1))

--- a/github/unlock-fb-protection.sh
+++ b/github/unlock-fb-protection.sh
@@ -68,10 +68,12 @@ echo "Modules in catalog: ${modules_length}"
 echo "Checking modules..."
 
 counter=0
+last_org=""
 
 while IFS=']' read -r line; do
     item="$(awk -F'project:' '{print $2}' <<< "$line" | cut -d',' -f1 | tr -d "'" | xargs)"
     org="$(awk -F'gitOrganization:' '{print $2}' <<< "$line" | cut -d',' -f1 | tr -d "']" | xargs)"
+    if [ -z "${org}" ] && [ -n "${last_org}" ]; then org="${last_org}"; elif [ -n "${org}" ]; then last_org="${org}"; fi
 
     [[ -z "$item" || -z "$org" ]] && continue
 


### PR DESCRIPTION
swf-jenkins-pipeline DSL seed files now auto-inherit gitOrganization from previous entries (carry-forward). Update parsers to match:

- rebase-fb.sh: track last_org across lines
- revrebase.sh: track last_org (was silently skipping entries)
- unlock-fb-protection.sh: track last_org (was silently skipping entries)
- rebase-branch-meeds.sh: already safe (DEFAULT_ORG fallback)